### PR TITLE
Add Vercel cron endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+last_allocation.json

--- a/allocationCron.js
+++ b/allocationCron.js
@@ -1,0 +1,47 @@
+const axios = require('axios');
+const fs = require('fs');
+const path = require('path');
+const fetchData = require('./api/fetchData');
+
+const STATE_FILE = path.join(__dirname, 'last_allocation.json');
+
+async function sendWebhook(title, message) {
+  if (process.env.DISCORD_WEBHOOK_URL) {
+    await axios.post(process.env.DISCORD_WEBHOOK_URL, {
+      content: `**${title}**\n${message}`,
+    });
+  } else {
+    console.log(`${title}: ${message}`);
+  }
+}
+
+async function checkAllocation(alwaysNotify = false, title = 'Allocation Update') {
+  const data = await fetchData.fetchCheckFinancialData();
+  const { recommendedAllocation } =
+    fetchData.determineRecommendationWithBands(data);
+  const current = recommendedAllocation;
+
+  let previous = null;
+  try {
+    previous = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8')).allocation;
+  } catch (e) {
+    // No previous file
+  }
+
+  const changed = previous !== current;
+  if (changed) {
+    fs.writeFileSync(STATE_FILE, JSON.stringify({ allocation: current }));
+  }
+
+  const status = changed
+    ? `Allocation changed to: ${current}`
+    : `No change in allocation: ${current}`;
+
+  if (alwaysNotify || changed) {
+    await sendWebhook(title, status);
+  }
+
+  return { previous, current, changed };
+}
+
+module.exports = { checkAllocation };

--- a/api/daily-update.js
+++ b/api/daily-update.js
@@ -1,0 +1,11 @@
+const { checkAllocation } = require('../allocationCron');
+
+module.exports = async (req, res) => {
+  try {
+    await checkAllocation(true, 'Daily Allocation Update');
+    res.status(200).json({ status: 'ok' });
+  } catch (err) {
+    console.error('daily update error', err);
+    res.status(500).json({ error: 'cron failure' });
+  }
+};

--- a/api/fetchData.js
+++ b/api/fetchData.js
@@ -196,3 +196,8 @@ module.exports = async (req, res) => {
     res.status(500).json({ error: e.message||"Server error" });
   }
 };
+
+// Named exports for reuse in cron and tests
+module.exports.fetchCheckFinancialData = fetchCheckFinancialData;
+module.exports.determineRiskCategory = determineRiskCategory;
+module.exports.determineRecommendationWithBands = determineRecommendationWithBands;

--- a/api/test-update.js
+++ b/api/test-update.js
@@ -1,0 +1,11 @@
+const { checkAllocation } = require('../allocationCron');
+
+module.exports = async (req, res) => {
+  try {
+    await checkAllocation(true, 'Test Update');
+    res.status(200).json({ status: 'ok' });
+  } catch (err) {
+    console.error('test update error', err);
+    res.status(500).json({ error: 'cron failure' });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"dependencies": {
 		"discord-interactions": "^2.0.2",
 		"raw-body": "^2.4.1",
-		"axios": "^1.5.0",
-		"yahoo-finance2": "^2.4.4"
-	}
+                "axios": "^1.5.0",
+                "yahoo-finance2": "^2.4.4"
+        }
 }

--- a/register-commands.js
+++ b/register-commands.js
@@ -36,6 +36,10 @@ const commands = [
             },
         ],
     },
+    {
+        name: 'test',
+        description: 'Run allocation change check.'
+    },
 ];
 
 // Create a REST instance and set the token

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "crons": [
+    { "path": "/api/daily-update", "schedule": "0 19 * * 1-5" },
+    { "path": "/api/test-update",  "schedule": "0 18 * * *" }
+  ]
+}


### PR DESCRIPTION
## Summary
- remove in-process cron scheduling
- expose allocation checker for new API endpoints
- add `/api/daily-update` and `/api/test-update` serverless functions
- configure Vercel cron jobs for daily and test updates

## Testing
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_687972326a388326b9410b7771a0c4f1