### PR TITLE
Update cron times for market hours

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "crons": [
-    { "path": "/api/daily-update", "schedule": "0 19 * * 1-5" },
-    { "path": "/api/test-update",  "schedule": "0 18 * * *" }
+    { "path": "/api/daily-update", "schedule": "0 20 * * 1-5" },
+    { "path": "/api/test-update",  "schedule": "30 14 * * 1-5" }
   ]
 }


### PR DESCRIPTION
## Summary
- change Vercel cron schedules to run 1h after market open and 1h before close

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687c36c6755483269017fe3b314fc4eb