### PR TITLE
Add env example and setup notes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Environment variables for the Discord bot
+
+# Discord bot token used when registering commands
+DISCORD_BOT_TOKEN=
+
+# Application (client) ID of the Discord application
+APPLICATION_ID=
+
+# Public key for verifying incoming interactions
+PUBLIC_KEY=
+
+# Bot token used by the API when responding to interactions
+BOT_TOKEN=
+
+# Webhook URL for allocation notifications
+DISCORD_WEBHOOK_URL=
+
+# Optional: path to store allocation state (defaults to an internal path)
+STATE_FILE=
+
+# Optional: automatically set on Vercel
+VERCEL=
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 package-lock.json
 last_allocation.json
+
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Discord Bot
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy the example environment file and edit it with your values:
+   ```bash
+   cp .env.example .env
+   # then open .env and fill in each variable
+   ```
+
+The `.env` file is excluded from version control so your secrets remain private.


### PR DESCRIPTION
## Summary
- list required environment variables in `.env.example`
- ignore `.env` in version control
- document copying `.env.example` in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687d6fac29ec8326be3a72fdbb0d1504